### PR TITLE
Moving extension methods from Microsoft to Rhetos namespace.

### DIFF
--- a/Plugins/Rhetos.LightDMS/LightDMSRhetosServiceCollectionBuilderExtensions.cs
+++ b/Plugins/Rhetos.LightDMS/LightDMSRhetosServiceCollectionBuilderExtensions.cs
@@ -20,11 +20,12 @@
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.DependencyInjection;
 using Rhetos.LightDMS;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace Rhetos
 {
     /// <summary>
     /// Adds the LightDMS Web API to the application.


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/core/extensions/options-library-authors: DO NOT use the Microsoft.Extensions.DependencyInjection namespace for non-official Microsoft packages.